### PR TITLE
Add dark mode and search improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,13 @@
             position: relative;
         }
 
+        body.dark-mode {
+            --primary-gradient: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
+            --text-primary: #e2e8f0;
+            --text-secondary: #cbd5e0;
+            --white: #2d3748;
+        }
+
         body::before {
             content: '';
             position: fixed;
@@ -139,6 +146,43 @@
             border-color: rgba(255, 255, 255, 0.3);
         }
 
+        .dark-mode-toggle {
+            background: var(--glass-bg);
+            backdrop-filter: blur(20px);
+            border: 1px solid var(--glass-border);
+            color: white;
+            border-radius: var(--border-radius);
+            padding: 8px 12px;
+            cursor: pointer;
+            font-size: 1.1rem;
+            transition: var(--transition);
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            z-index: 10;
+        }
+
+        .dark-mode-toggle:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-medium);
+        }
+
+        .supplies-controls {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .favorites-toggle {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+
         .main-grid {
             display: grid;
             grid-template-columns: 1fr 400px;
@@ -229,6 +273,26 @@
             transform: translateY(-8px) scale(1.02);
             box-shadow: var(--shadow-medium);
             border-color: rgba(102, 126, 234, 0.2);
+        }
+
+        .favorite-btn {
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            font-size: 1.4rem;
+            color: var(--text-secondary);
+            cursor: pointer;
+            transition: var(--transition);
+            z-index: 2;
+        }
+
+        .favorite-btn.active {
+            color: #f6ad55;
+            transform: scale(1.2);
+        }
+
+        .supply-card.favorite {
+            border-color: #f6ad55;
         }
 
         .supply-image-container {
@@ -811,6 +875,23 @@
             box-shadow: 0 8px 25px rgba(79, 172, 254, 0.4);
         }
 
+        .clear-history-btn {
+            background: linear-gradient(135deg, #f56565 0%, #ed64a6 100%);
+            color: white;
+            border: none;
+            padding: 12px 20px;
+            border-radius: 10px;
+            cursor: pointer;
+            font-weight: 600;
+            transition: var(--transition);
+            box-shadow: 0 4px 15px rgba(245, 101, 101, 0.3);
+        }
+
+        .clear-history-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(245, 101, 101, 0.4);
+        }
+
         .order-item {
             background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
             border-radius: var(--border-radius);
@@ -945,6 +1026,7 @@
 </head>
 <body>
     <div class="container">
+        <button class="dark-mode-toggle" onclick="toggleDarkMode()">🌙</button>
         <header class="header">
             <div class="header-decoration">🧽</div>
             <h1>Cleaning Supplies Platform</h1>
@@ -958,7 +1040,20 @@
         <div class="main-grid">
             <section class="supplies-section">
                 <h2 class="section-title">🧽 Available Supplies</h2>
-                
+
+                <input type="text" id="supplySearch" class="form-input" placeholder="Search supplies..." oninput="filterSupplies()" style="margin-bottom: 20px;">
+
+                <div class="supplies-controls">
+                    <select id="categoryFilter" class="select-input" style="width:auto;" onchange="filterSupplies()"></select>
+                    <select id="sortSupplies" class="select-input" style="width:auto;" onchange="filterSupplies()">
+                        <option value="az">Sort A-Z</option>
+                        <option value="za">Sort Z-A</option>
+                    </select>
+                    <label class="favorites-toggle">
+                        <input type="checkbox" id="showFavorites" onchange="filterSupplies()"> Favorites
+                    </label>
+                </div>
+
                 <div class="supplies-grid" id="suppliesGrid">
                     <!-- Supply cards will be generated here -->
                 </div>
@@ -1055,6 +1150,7 @@
                 </select>
                 <input type="text" id="itemFilter" class="form-input" style="width: auto; min-width: 200px;" placeholder="Filter by item name..." oninput="filterOrders()">
                 <button class="export-btn" onclick="exportToCSV()">📄 Export CSV</button>
+                <button class="clear-history-btn" onclick="clearOrderHistory()">🗑️ Clear History</button>
             </div>
             
             <div id="orderHistoryList">
@@ -1071,33 +1167,41 @@
 
         // Predefined supplies data
         const predefinedSupplies = [
-            { id: 'paperTowels', name: 'Paper Towels', unit: 'roll', imageSrc: 'https://i.postimg.cc/3rzyvZyP/Chat-GPT-Image-Jun-2-2025-11-26-57-AM.png' },
-            { id: 'toiletPaper', name: 'Toilet Paper', unit: 'roll', imageSrc: 'https://i.postimg.cc/7Y75MT0b/Chat-GPT-Image-Jun-2-2025-11-40-01-AM.png' },
-            { id: 'plasticBags', name: 'Plastic Bags', unit: 'roll', imageSrc: 'https://i.postimg.cc/3xFWz5LT/Garbage-Bag-with-Soft-Lighting.png' },
-            { id: 'gloves', name: 'Disposable Gloves', unit: 'box', imageSrc: 'https://i.postimg.cc/Kc1kjWYP/Chat-GPT-Image-Jun-2-2025-11-48-44-AM.png' },
-            { id: 'soap', name: 'Hand Soap', unit: 'bottle', imageSrc: 'https://i.postimg.cc/jCVrS2SF/Chat-GPT-Image-Jun-2-2025-11-45-17-AM.png' }
+            { id: 'paperTowels', name: 'Paper Towels', unit: 'roll', category: 'paper', imageSrc: 'https://i.postimg.cc/3rzyvZyP/Chat-GPT-Image-Jun-2-2025-11-26-57-AM.png' },
+            { id: 'toiletPaper', name: 'Toilet Paper', unit: 'roll', category: 'paper', imageSrc: 'https://i.postimg.cc/7Y75MT0b/Chat-GPT-Image-Jun-2-2025-11-40-01-AM.png' },
+            { id: 'plasticBags', name: 'Plastic Bags', unit: 'roll', category: 'disposal', imageSrc: 'https://i.postimg.cc/3xFWz5LT/Garbage-Bag-with-Soft-Lighting.png' },
+            { id: 'gloves', name: 'Disposable Gloves', unit: 'box', category: 'safety', imageSrc: 'https://i.postimg.cc/Kc1kjWYP/Chat-GPT-Image-Jun-2-2025-11-48-44-AM.png' },
+            { id: 'soap', name: 'Hand Soap', unit: 'bottle', category: 'cleaning', imageSrc: 'https://i.postimg.cc/jCVrS2SF/Chat-GPT-Image-Jun-2-2025-11-45-17-AM.png' }
         ];
 
         // Supply quantities
         let supplyQuantities = {};
 
         // Initialize the application
+        let darkMode = localStorage.getItem('darkMode') === 'true';
+        let favoriteSupplies = JSON.parse(localStorage.getItem('favoriteSupplies') || '[]');
+
         function initializeApp() {
             predefinedSupplies.forEach(supply => {
                 supplyQuantities[supply.id] = 1;
             });
-            renderSupplies();
+            populateCategoryFilter();
+            filterSupplies();
             updateOrderButton();
             populateCleanerFilter();
+            applyDarkMode();
         }
 
         // Render predefined supplies
-        function renderSupplies() {
+        function renderSupplies(list = predefinedSupplies) {
             const suppliesGrid = document.getElementById('suppliesGrid');
-            suppliesGrid.innerHTML = predefinedSupplies.map(supply => `
-                <div class="supply-card" data-supply-id="${supply.id}">
+            suppliesGrid.innerHTML = list.map(supply => {
+                const fav = favoriteSupplies.includes(supply.id);
+                return `
+                <div class="supply-card ${fav ? 'favorite' : ''}" data-supply-id="${supply.id}">
+                    <div class="favorite-btn ${fav ? 'active' : ''}" onclick="toggleFavorite('${supply.id}', event)">${fav ? '★' : '☆'}</div>
                     <div class="supply-image-container">
-                        <img class="supply-image" src="${supply.imageSrc}" alt="${supply.name}" 
+                        <img class="supply-image" src="${supply.imageSrc}" alt="${supply.name}"
                              onerror="this.classList.add('error')">
                         <div class="fallback-icon">📦</div>
                     </div>
@@ -1112,7 +1216,8 @@
                         Add to Cart
                     </button>
                 </div>
-            `).join('');
+                `;
+            }).join('');
         }
 
         // Change quantity for predefined supplies
@@ -1120,10 +1225,36 @@
             supplyQuantities[supplyId] = Math.max(1, supplyQuantities[supplyId] + change);
             const qtyDisplay = document.getElementById(`qty-${supplyId}`);
             qtyDisplay.textContent = supplyQuantities[supplyId];
-            
+
             // Add a pulse animation to show the change
             qtyDisplay.classList.add('pulse');
             setTimeout(() => qtyDisplay.classList.remove('pulse'), 1000);
+        }
+
+        function filterSupplies() {
+            const query = document.getElementById('supplySearch').value.toLowerCase();
+            const category = document.getElementById('categoryFilter').value;
+            const showFav = document.getElementById('showFavorites').checked;
+            const sortDir = document.getElementById('sortSupplies').value;
+
+            let list = predefinedSupplies.filter(s => s.name.toLowerCase().includes(query));
+            if (category) list = list.filter(s => s.category === category);
+            if (showFav) list = list.filter(s => favoriteSupplies.includes(s.id));
+            list.sort((a, b) => sortDir === 'az' ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name));
+
+            renderSupplies(list);
+        }
+
+        function toggleFavorite(id, e) {
+            e.stopPropagation();
+            const idx = favoriteSupplies.indexOf(id);
+            if (idx >= 0) {
+                favoriteSupplies.splice(idx, 1);
+            } else {
+                favoriteSupplies.push(id);
+            }
+            localStorage.setItem('favoriteSupplies', JSON.stringify(favoriteSupplies));
+            filterSupplies();
         }
 
         // Create drop animation
@@ -1464,9 +1595,16 @@
         function populateCleanerFilter() {
             const cleanerFilter = document.getElementById('cleanerFilter');
             const cleaners = [...new Set(orders.map(order => order.cleaner))];
-            
-            cleanerFilter.innerHTML = '<option value="">All Cleaners</option>' + 
+
+            cleanerFilter.innerHTML = '<option value="">All Cleaners</option>' +
                 cleaners.map(cleaner => `<option value="${cleaner}">${cleaner}</option>`).join('');
+        }
+
+        function populateCategoryFilter() {
+            const categoryFilter = document.getElementById('categoryFilter');
+            const categories = [...new Set(predefinedSupplies.map(s => s.category))];
+            categoryFilter.innerHTML = '<option value="">All Categories</option>' +
+                categories.map(c => `<option value="${c}">${c.charAt(0).toUpperCase() + c.slice(1)}</option>`).join('');
         }
 
         // Filter orders
@@ -1512,8 +1650,19 @@
             a.click();
             document.body.removeChild(a);
             window.URL.revokeObjectURL(url);
-            
+
             showToast('Orders exported successfully!');
+        }
+
+        function clearOrderHistory() {
+            if (!confirm('Are you sure you want to clear all order history?')) return;
+            orders = [];
+            orderCounter = 1;
+            localStorage.removeItem('cleaningOrders');
+            localStorage.removeItem('orderCounter');
+            populateCleanerFilter();
+            renderOrderHistory();
+            showToast('Order history cleared!');
         }
 
         // Enhanced toast notification with better animations
@@ -1540,13 +1689,31 @@
             }, 3000);
         }
 
+        function toggleDarkMode() {
+            darkMode = !darkMode;
+            localStorage.setItem('darkMode', darkMode.toString());
+            applyDarkMode();
+        }
+
+        function applyDarkMode() {
+            const body = document.body;
+            const btn = document.querySelector('.dark-mode-toggle');
+            if (darkMode) {
+                body.classList.add('dark-mode');
+                if (btn) btn.textContent = '☀️';
+            } else {
+                body.classList.remove('dark-mode');
+                if (btn) btn.textContent = '🌙';
+            }
+        }
+
         // Close modal when clicking outside
         window.onclick = function(event) {
             const modal = document.getElementById('orderHistoryModal');
             if (event.target === modal) {
                 closeOrderHistory();
             }
-        }
+        };
 
         // Listen for custom cleaner input changes
         document.getElementById('customCleanerName').addEventListener('input', updateOrderButton);


### PR DESCRIPTION
## Summary
- add CSS variables for dark mode
- support dark mode toggle in UI
- add search bar to filter supplies
- add button to clear order history
- persist dark mode preference and new filtering logic
- fix missing semicolon in modal close handler

## Testing
- `tidy -e index.html`
- `jshint --config <(echo '{"esversion": 6}') script.js`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f8a55573883288b0edfcd789a8277